### PR TITLE
Added support for Bundler to manage ruby dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+
+gem "albacore"
+gem "rake", "0.9.2.2"
+gem "rubyzip"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    albacore (0.3.4)
+      rubyzip
+    rake (0.9.2.2)
+    rubyzip (0.9.9)
+
+PLATFORMS
+  x86-mingw32
+
+DEPENDENCIES
+  albacore
+  rake (= 0.9.2.2)
+  rubyzip

--- a/InstallGems.bat
+++ b/InstallGems.bat
@@ -1,15 +1,7 @@
-@SETLOCAL
-@set rakeversion=""
-@FOR /f "tokens=2" %%a in ('rake --version') do @set rakeversion=%%a 
-@IF /I NOT "%rakeversion%" EQU "version " (
-@ENDLOCAL
-@ECHO *** Installing Rake
-@call gem install rake --no-rdoc --no-ri
-)
-@ENDLOCAL
+@ECHO OFF
+SETLOCAL
 
-@ECHO *** Installing RubyZip
-@call gem install rubyzip --no-rdoc --no-ri
+@call bundle -v
+IF ERRORLEVEL 1 (@call gem install bundler)
 
-@ECHO *** Installing Albacore (build support tools)
-@call gem install albacore --no-rdoc --no-ri
+@call bundle install

--- a/push.bat
+++ b/push.bat
@@ -1,6 +1,6 @@
 cd \code\ripple
-rake
-rake publish
+bundle exec rake
+bundle exec rake publish
 cd \code\buildsupport
 git commit -a -m "new stuff"
 git push origin

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,3 +1,5 @@
+require 'bundler/setup'
+
 COMPILE_TARGET = ENV['config'].nil? ? "debug" : ENV['config']
 CLR_TOOLS_VERSION = "v4.0.30319"
 

--- a/run-rake.cmd
+++ b/run-rake.cmd
@@ -1,1 +1,1 @@
-rake %*
+bundle exec rake %*


### PR DESCRIPTION
I currently have Rake 10.0.2 installed which is problematic, since the rakefile for this repo is written against 0.9.2.2. Bundler allows you to run specifically against that version of rake via `bundle exec rake`.

Just as an FYI I use a bash alias for `bundle exec rake` to `bake` just to make life easier for me.
