### PR TITLE
Fixed gemfile rubygems warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "albacore"
 gem "rake", "10.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     albacore (0.3.4)
       rubyzip


### PR DESCRIPTION
Fixes the bundler warning to use https://rubygems.org
