### PR TITLE
Rescue when bundler is missing

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,4 +1,13 @@
-require 'bundler/setup'
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'Bundler needs to be installed prior to running this rake script.'
+  puts ''
+  puts 'Run: gem install bundler'
+  puts ''
+  exit 0
+end
+
 require 'rubygems/package_task'
 COMPILE_TARGET = ENV['config'].nil? ? "debug" : ENV['config']
 CLR_TOOLS_VERSION = "v4.0.30319"

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,10 +1,9 @@
 begin
   require 'bundler/setup'
 rescue LoadError
-  puts 'Bundler needs to be installed prior to running this rake script.'
-  puts ''
-  puts 'Run: gem install bundler'
-  puts ''
+  puts 'Bundler needs to be installed prior to running this rake script. Installing...'
+  system("gem install bundler")
+  system("bundle exec rake", *ARGV)
   exit 0
 end
 


### PR DESCRIPTION
Here is a potential idea for ensuring that bundler is installed for those who pull down a fresh clone. The basic idea here is that we can rescue a LoadError in ruby if we fail to require in bundler. Then we can just install it for them. Also, we can re-attempt to run the same command that they originally tried. This can stand as a model for the rakefiles of each repo, so I'd like to get it right in one before I work to roll it out to each of the others.
