### PR TITLE
Caching on multiple levels

### DIFF
--- a/src/ripple.sln
+++ b/src/ripple.sln
@@ -53,4 +53,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 EndGlobal

--- a/src/ripple.sln
+++ b/src/ripple.sln
@@ -53,7 +53,4 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 EndGlobal

--- a/src/ripple/Model/FeedRegistry.cs
+++ b/src/ripple/Model/FeedRegistry.cs
@@ -12,7 +12,7 @@ namespace ripple.Model
 	public class FeedProvider : IFeedProvider
 	{
 		private readonly Cache<Feed, INugetFeed> _feeds;
-
+        
 		public FeedProvider()
 		{
 			_feeds = new Cache<Feed, INugetFeed>(buildFeed);
@@ -32,7 +32,7 @@ namespace ripple.Model
 
 			if (feed.Mode == UpdateMode.Fixed)
 			{
-				return new NugetFeed(feed.Url, feed.Stability);
+                return new NugetFeed(feed.Url, feed.Stability);
 			}
 
             return new FloatingFeed(feed.Url, feed.Stability);

--- a/src/ripple/Nuget/FileSystemNugetFeed.cs
+++ b/src/ripple/Nuget/FileSystemNugetFeed.cs
@@ -10,11 +10,12 @@ using ripple.Model;
 
 namespace ripple.Nuget
 {
-    public class FileSystemNugetFeed : INugetFeed
+    public class FileSystemNugetFeed : NugetFeedBase
     {
         private readonly string _directory;
         private readonly FubuCore.IFileSystem _fileSystem;
         private readonly NugetStability _stability;
+        private IPackageRepository _repository;
 
         public FileSystemNugetFeed(string directory, NugetStability stability)
         {
@@ -59,7 +60,7 @@ namespace ripple.Nuget
             return new FileSystemNuget(file); 
         }
 
-        public IRemoteNuget Find(Dependency query)
+        protected override IRemoteNuget FindImpl(Dependency query)
         {
             RippleLog.Debug("Searching for {0} in {1}".ToFormat(query, _directory));
 
@@ -73,7 +74,7 @@ namespace ripple.Nuget
             return findMatching(nuget => query.MatchesName(nuget.Name) && nuget.Version == version);
         }
 
-        public IRemoteNuget FindLatest(Dependency query)
+        protected override IRemoteNuget FindLatestImpl(Dependency query)
         {
             RippleLog.Debug("Searching for latest of {0} in {1}".ToFormat(query, _directory));
 
@@ -93,7 +94,10 @@ namespace ripple.Nuget
             return new FileSystemNuget(nuget);
         }
 
-        public IPackageRepository Repository { get; private set; }
+        public override IPackageRepository Repository
+        {
+            get { return _repository; }
+        }
 
         public override string ToString()
         {

--- a/src/ripple/Nuget/INugetFeed.cs
+++ b/src/ripple/Nuget/INugetFeed.cs
@@ -6,8 +6,8 @@ namespace ripple.Nuget
     public interface INugetFeed
     {
         IRemoteNuget Find(Dependency query);
-		IRemoteNuget FindLatest(Dependency query);
+        IRemoteNuget FindLatest(Dependency query);
 
-		IPackageRepository Repository { get; }
+        IPackageRepository Repository { get; }
     }
 }

--- a/src/ripple/Nuget/NugetFeed.cs
+++ b/src/ripple/Nuget/NugetFeed.cs
@@ -5,7 +5,7 @@ using ripple.Model;
 
 namespace ripple.Nuget
 {
-    public class NugetFeed : INugetFeed
+    public class NugetFeed : NugetFeedBase
     {
         private readonly IPackageRepository _repository;
         private readonly string _url;
@@ -23,7 +23,7 @@ namespace ripple.Nuget
             get { return _url; }
         }
 
-		public IRemoteNuget Find(Dependency query)
+        protected override IRemoteNuget FindImpl(Dependency query)
 		{
 			SemanticVersion version;
 			if (!SemanticVersion.TryParse(query.Version, out version))
@@ -43,8 +43,7 @@ namespace ripple.Nuget
             return new RemoteNuget(package);
         }
 
-
-		public IRemoteNuget FindLatest(Dependency query)
+        protected override IRemoteNuget FindLatestImpl(Dependency query)
         {
 			RippleLog.Debug("Searching for {0} from {1}".ToFormat(query, _url));
             var candidates = _repository.Search(query.Name, query.DetermineStability(_stability) == NugetStability.Anything)
@@ -61,6 +60,6 @@ namespace ripple.Nuget
             return new RemoteNuget(candidate);
         }
 
-		public IPackageRepository Repository { get { return _repository; } }
+		public override IPackageRepository Repository { get { return _repository; } }
     }
 }

--- a/src/ripple/Nuget/NugetFeedBase.cs
+++ b/src/ripple/Nuget/NugetFeedBase.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using NuGet;
+using ripple.Model;
+
+namespace ripple.Nuget
+{
+    public abstract class NugetFeedBase : INugetFeed
+    {
+        private static readonly NullRemoteNuget Null = new NullRemoteNuget();
+        private readonly Dictionary<Dependency, IRemoteNuget> _findCache = new Dictionary<Dependency, IRemoteNuget>();
+        private readonly Dictionary<string, IRemoteNuget> _findLatest = new Dictionary<string, IRemoteNuget>();
+        
+        public IRemoteNuget Find(Dependency query)
+        {
+            IRemoteNuget nuget;
+            if (_findCache.TryGetValue(query, out nuget) == false)
+            {
+                nuget = FindImpl(query);
+                _findCache[query] = nuget ?? Null;
+            }
+
+            return Return(nuget);
+        }
+
+        protected abstract IRemoteNuget FindImpl(Dependency query);
+
+        public IRemoteNuget FindLatest(Dependency query)
+        {
+            IRemoteNuget nuget;
+            if (_findLatest.TryGetValue(query.Name, out nuget) == false)
+            {
+                nuget = FindLatestImpl(query);
+
+                _findLatest[query.Name] = nuget ?? Null;
+
+                if (nuget != null && nuget.Version != null)
+                {
+                    var key = new Dependency(nuget.Name, nuget.Version.ToString());
+
+                    if (_findCache.ContainsKey(key) == false)
+                        _findCache[key] = nuget;
+                }
+            }
+
+            return Return(nuget);
+        }
+
+        protected abstract IRemoteNuget FindLatestImpl(Dependency query);
+
+        private static IRemoteNuget Return(object nuget)
+        {
+            if (ReferenceEquals(Null, nuget))
+                return null;
+
+            return (IRemoteNuget) nuget;
+        }
+
+        public abstract IPackageRepository Repository { get; }
+
+        private class NullRemoteNuget : IRemoteNuget
+        {
+            public string Name { get; private set; }
+            public SemanticVersion Version { get; private set; }
+            public INugetFile DownloadTo(Solution solution, string directory)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public string Filename { get; private set; }
+            public IEnumerable<Dependency> Dependencies()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/ripple/ripple.csproj
+++ b/src/ripple/ripple.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Nuget\IRemoteNuget.cs" />
     <Compile Include="Nuget\LocalDependencies.cs" />
     <Compile Include="Nuget\NugetFeed.cs" />
+    <Compile Include="Nuget\NugetFeedBase.cs" />
     <Compile Include="Nuget\NugetFile.cs" />
     <Compile Include="Nuget\NugetFolderCache.cs" />
     <Compile Include="Nuget\NugetPlan.cs" />


### PR DESCRIPTION
A few levels of caching:
- FeedService caches results of its methods (DependenciesFor, NugetFor) according to depdency and mode passed as parameters
- implementors of INugetFeed cache FindLatest, Find results, including nulls returned by a given nuget feed

This result in a performance boost for projects with a quite complex dependency graph.
