### PR TITLE
Solution NugetCacheFolder now is considered as cache folder

### DIFF
--- a/src/ripple/Model/Solution.cs
+++ b/src/ripple/Model/Solution.cs
@@ -48,6 +48,7 @@ namespace ripple.Model
         private Lazy<DependencyCollection> _dependencies;
         private readonly IList<NugetSpec> _nugetDependencies = new List<NugetSpec>();
         private string _path;
+        private string _cacheLocalPath;
 
         public Solution()
         {
@@ -71,6 +72,8 @@ namespace ripple.Model
             UsePublisher(PublishingService.For(Mode));
             UseBuilder(new NugetPlanBuilder());
 
+            _cacheLocalPath = Cache.LocalPath;
+
             RestoreSettings = new RestoreSettings();
             NuspecSettings = new NuspecSettings();
 
@@ -82,7 +85,19 @@ namespace ripple.Model
         public string SourceFolder { get; set; }
         public string BuildCommand { get; set; }
         public string FastBuildCommand { get; set; }
-        public string NugetCacheDirectory { get; set; }
+        
+        public string NugetCacheDirectory
+        {
+            get { return _cacheLocalPath; }
+            set
+            {
+                if (value.IsNotEmpty())
+                {
+                    _cacheLocalPath = value;
+                    UseCache(NugetFolderCache.DefaultFor(this));
+                }
+            }
+        }
 
         public string DefaultFloatConstraint
         {

--- a/src/ripple/Nuget/INugetCache.cs
+++ b/src/ripple/Nuget/INugetCache.cs
@@ -16,6 +16,7 @@ namespace ripple.Nuget
 	    IRemoteNuget Retrieve(IRemoteNuget nuget);
 
         Feed ToFeed();
+        string LocalPath { get; }
     }
 
 	public class NulloNugetCache : INugetCache
@@ -51,5 +52,7 @@ namespace ripple.Nuget
 	    {
 	        return null;
 	    }
+
+	    public string LocalPath { get { return null; } }
 	}
 }


### PR DESCRIPTION
A fix to the Solution, to make it use a NuGet cache folder specified in ripple.config
