### PR TITLE
ripple init: added context to error to show found ripple.config path.

### DIFF
--- a/src/ripple.Testing/Commands/initializing_an_existing_ripple_solution.cs
+++ b/src/ripple.Testing/Commands/initializing_an_existing_ripple_solution.cs
@@ -1,4 +1,5 @@
-﻿using FubuTestingSupport;
+﻿using FubuCore;
+using FubuTestingSupport;
 using NUnit.Framework;
 using ripple.Commands;
 
@@ -34,7 +35,7 @@ namespace ripple.Testing.Commands
             {
                 new InitCommand().Execute(new InitInput());
 
-            }).Message.ShouldEqual(InitCommand.ExistingSolution);
+			}).Message.ShouldEqual(InitCommand.ExistingSolution.ToFormat(theScenario.DirectoryForSolution("Test")));
         }
     }
 }

--- a/src/ripple.Testing/ForceDeleteTester.cs
+++ b/src/ripple.Testing/ForceDeleteTester.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿using System.IO;
 using System.Linq;
 using FubuCore;
 using FubuTestingSupport;
 using NUnit.Framework;
+using ripple.Commands;
 
 namespace ripple.Testing
 {
@@ -17,7 +18,7 @@ namespace ripple.Testing
         {
             theFileSystem = new FileSystem();
 
-            theDirectory = Guid.NewGuid().ToString();
+			theDirectory = Path.GetTempPath().AppendRandomPath();
             theFileSystem.CreateDirectory(theDirectory);
 
             createFile("1.txt");

--- a/src/ripple.Testing/Model/SolutionFilesTester.cs
+++ b/src/ripple.Testing/Model/SolutionFilesTester.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using FubuCore;
 using FubuTestingSupport;
 using NUnit.Framework;
+using ripple.Commands;
 using ripple.Model;
 
 namespace ripple.Testing.Model
@@ -28,7 +28,7 @@ namespace ripple.Testing.Model
 			theFileSystem.CreateDirectory("SolutionFiles");
 
 			theSolutionFiles = new SolutionFiles(theFileSystem, new SolutionLoader());
-			theSolutionFiles.RootDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SolutionFiles");
+			theSolutionFiles.RootDir = Path.GetTempPath().AppendRandomPath();
 			
 			theFileSystem.CreateDirectory("SolutionFiles", "src");
 
@@ -42,7 +42,7 @@ namespace ripple.Testing.Model
 		[TearDown]
 		public void TearDown()
 		{
-			theFileSystem.DeleteDirectory("SolutionFiles");
+			theFileSystem.DeleteDirectory(theSolutionFiles.RootDir);
 		}
 
 		[Test]

--- a/src/ripple.Testing/RippleFileSystemTester.cs
+++ b/src/ripple.Testing/RippleFileSystemTester.cs
@@ -2,6 +2,7 @@
 using FubuCore;
 using FubuTestingSupport;
 using NUnit.Framework;
+using ripple.Commands;
 using ripple.Model;
 
 namespace ripple.Testing
@@ -12,15 +13,18 @@ namespace ripple.Testing
         private string theSolutionDir;
         private string theCurrentDir;
         private string theCodeDir;
+	    private FileSystem fileSystem;
+	    private string rootDir;
 
-        [SetUp]
+	    [SetUp]
         public void SetUp()
-        {
-            theCodeDir = ".".AppendPath("code");
+	    {
+			rootDir = Path.GetTempPath().AppendRandomPath();
+            theCodeDir = rootDir.AppendPath("code");
             theSolutionDir = theCodeDir.AppendPath("ripple");
             theCurrentDir = theSolutionDir.AppendPath("src", "project1");
 
-            var fileSystem = new FileSystem();
+            fileSystem = new FileSystem();
             fileSystem.CreateDirectory(theCodeDir);
             fileSystem.CreateDirectory(theSolutionDir);
             fileSystem.CreateDirectory(theCurrentDir);
@@ -33,8 +37,7 @@ namespace ripple.Testing
         [TearDown]
         public void TearDown()
         {
-            var fileSystem = new FileSystem();
-            fileSystem.DeleteDirectory(theCodeDir);
+            fileSystem.DeleteDirectory(rootDir);
 
             RippleFileSystem.Live();
         }
@@ -57,6 +60,16 @@ namespace ripple.Testing
             RippleFileSystem.FindSolutionDirectory().ShouldEqual(theSolutionDir.ToFullPath());
         }
 
+		[Test]
+		public void finding_the_solution_dir_with_do_not_throw_argument_should_not_throw()
+		{
+			var nonSolutionDir = theCodeDir.AppendPath("not-a-solution-dir");
+			fileSystem.CreateDirectory(nonSolutionDir);
+			RippleFileSystem.StubCurrentDirectory(nonSolutionDir);
+
+			RippleFileSystem.FindSolutionDirectory(false).ShouldBeNull();
+		}
+
         [Test]
         public void finds_the_code_dir()
         {
@@ -69,11 +82,13 @@ namespace ripple.Testing
     {
         private string theSolutionDir;
         private string theCodeDir;
+	    private string rootDir;
 
-        [SetUp]
+	    [SetUp]
         public void SetUp()
         {
-            theCodeDir = ".".AppendPath("code");
+			rootDir = Path.GetTempPath().AppendRandomPath();
+            theCodeDir = rootDir.AppendPath("code");
             theSolutionDir = theCodeDir.AppendPath("ripple");
 
             var fileSystem = new FileSystem();
@@ -90,7 +105,7 @@ namespace ripple.Testing
         public void TearDown()
         {
             var fileSystem = new FileSystem();
-            fileSystem.DeleteDirectory(theCodeDir);
+            fileSystem.DeleteDirectory(rootDir);
 
             RippleFileSystem.Live();
         }

--- a/src/ripple/Commands/InitCommand.cs
+++ b/src/ripple/Commands/InitCommand.cs
@@ -11,7 +11,7 @@ namespace ripple.Commands
 
         public override bool Execute(InitInput input)
         {
-	        var rippleConfigDirectory = RippleFileSystem.FindSolutionDirectory();
+	        var rippleConfigDirectory = RippleFileSystem.FindSolutionDirectory(false);
 	        if (rippleConfigDirectory.IsNotEmpty())
             {
                 RippleAssert.Fail(ExistingSolution.ToFormat(rippleConfigDirectory));

--- a/src/ripple/Commands/InitCommand.cs
+++ b/src/ripple/Commands/InitCommand.cs
@@ -1,3 +1,4 @@
+using FubuCore;
 using FubuCore.CommandLine;
 using ripple.Model;
 
@@ -6,13 +7,14 @@ namespace ripple.Commands
     [CommandDescription("Initialize a new ripple solution")]
     public class InitCommand : FubuCommand<InitInput>
     {
-        public const string ExistingSolution = "Cannot initialize existing solution";
+        public const string ExistingSolution = "Cannot initialize an existing ripplized solution. I found a ripple.config at: {0}";
 
         public override bool Execute(InitInput input)
         {
-            if (RippleFileSystem.IsSolutionDirectory())
+	        var rippleConfigDirectory = RippleFileSystem.FindSolutionDirectory();
+	        if (rippleConfigDirectory.IsNotEmpty())
             {
-                RippleAssert.Fail(ExistingSolution);
+                RippleAssert.Fail(ExistingSolution.ToFormat(rippleConfigDirectory));
                 return false;
             }
 

--- a/src/ripple/Commands/InitInput.cs
+++ b/src/ripple/Commands/InitInput.cs
@@ -57,5 +57,10 @@ namespace ripple.Commands
                 continuation(value);
             }
         }
+
+		public static string AppendRandomPath(this string path)
+		{
+			return path.AppendPath((Guid.NewGuid().ToString().Replace("-", String.Empty)));
+		}
     }
 }

--- a/src/ripple/MSBuild/CsProjFile.cs
+++ b/src/ripple/MSBuild/CsProjFile.cs
@@ -40,11 +40,18 @@ namespace ripple.MSBuild
             _filename = filename;
             _solution = solution;
 
-            _document = XElement.Load(filename);
-	        _document.Name = _xmlns + _document.Name.LocalName;
+	        try
+	        {
+		        _document = XElement.Load(filename);
+		        _document.Name = _xmlns + _document.Name.LocalName;
 
-            _references = new Lazy<IList<Reference>>(() => new List<Reference>(readReferences()));
-            _projectReferences = new Lazy<IList<string>>(() => new List<string>(readProjectReferences()));
+		        _references = new Lazy<IList<Reference>>(() => new List<Reference>(readReferences()));
+		        _projectReferences = new Lazy<IList<string>>(() => new List<string>(readProjectReferences()));
+	        }
+	        catch (Exception ex)
+	        {
+		        throw new RippleFatalError("Error reading csproj file: {0}".ToFormat(filename), ex);
+	        }
         }
 
         public string ToolsVersion

--- a/src/ripple/RippleFileSystem.cs
+++ b/src/ripple/RippleFileSystem.cs
@@ -44,7 +44,7 @@ namespace ripple
         }
 
         public static bool IsCodeDirectory()
-        {
+	      {
             if (IsSolutionDirectory()) return false;
 
             // We only traverse one level here

--- a/src/ripple/RippleFileSystem.cs
+++ b/src/ripple/RippleFileSystem.cs
@@ -33,9 +33,9 @@ namespace ripple
             _stopAt = dir => dir.ToFullPath() == directory.ToFullPath();
         }
 
-        public static string FindSolutionDirectory()
+        public static string FindSolutionDirectory(bool shouldThrow = true)
         {
-            return findSolutionDir(_currentDir());
+            return findSolutionDir(_currentDir(), shouldThrow);
         }
 
         public static bool IsSolutionDirectory()

--- a/src/ripple/RippleLog.cs
+++ b/src/ripple/RippleLog.cs
@@ -8,10 +8,8 @@ namespace ripple
 {
     public class RippleFatalError : Exception
     {
-        public RippleFatalError(string message)
-            : base(message)
-        {
-        }
+        public RippleFatalError(string message) : base(message) { }
+		public RippleFatalError(string message, Exception ex) : base(message,ex) { }
     }
 
     public class RippleAssert


### PR DESCRIPTION
Trying to add context to an error so users can find the ripple.config that is controlling their destiny.
## Cavet

I updated the test I broke with this change but on my system I had 2 tests fail in teardown related to file/directory cleanup. Did a  `git clean -dfx` and then only one test failed. rake-d again and no tests failed. The failure is in DeleteDirectory which is a FubuCore thing. Is this a known problem?

```
Tests run: 326, Errors: 2, Failures: 0, Inconclusive: 0, Time: 8.636494 seconds
  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0

Errors and Failures:
1) TearDown Error : ripple.Testing.from_a_solution_dir.finds_the_code_dir
   TearDown : System.IO.IOException : The directory is not empty.

--TearDown
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at FubuCore.FileSystem.DeleteDirectory(String directory) in c:\BuildAgent\work\4dafc5966c0aefb4\src\FubuCore\FileSystem.cs:line 145
   at ripple.Testing.from_a_solution_dir.TearDown() in c:\projects\ripple\src\ripple.Testing\RippleFileSystemTester.cs:line 37

2) TearDown Error : ripple.Testing.Model.SolutionFilesTester.reads_the_projects
   TearDown : System.IO.IOException : The directory is not empty.

--TearDown
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
   at FubuCore.FileSystem.DeleteDirectory(String directory) in c:\BuildAgent\work\4dafc5966c0aefb4\src\FubuCore\FileSystem.cs:line 145
   at ripple.Testing.Model.SolutionFilesTester.TearDown() in c:\projects\ripple\src\ripple.Testing\Model\SolutionFilesTester.cs:line 45
```
