### PR TITLE
RestoreCommand does not FixReferences any more

### DIFF
--- a/src/ripple/Commands/RestoreCommand.cs
+++ b/src/ripple/Commands/RestoreCommand.cs
@@ -8,7 +8,7 @@ using ripple.Steps;
 
 namespace ripple.Commands
 {
-    public class RestoreInput : SolutionInput, IOverrideFeeds
+    public class RestoreInput : SolutionInput, IOverrideFeeds, IManageReferenceFixing
     {
         [Description("Additional NuGet feed urls separated by '#'")]
         public string FeedsFlag { get; set; }
@@ -16,6 +16,10 @@ namespace ripple.Commands
         [Description("Forces the restoration to correct any version mismatches")]
         [FlagAlias("force", 'f')]
         public bool ForceFlag { get; set; }
+
+        [Description("Makes the restore go through project references' fixing.")]
+        [FlagAlias("fix-references", 'r')]
+        public bool FixReferencesFlag { get; set; }
 
         public override string DescribePlan(Solution solution)
         {
@@ -33,6 +37,11 @@ namespace ripple.Commands
         public IEnumerable<Feed> Feeds()
         {
             return FeedsFlag.GetFeeds();
+        }
+
+        public bool ShouldReferencesBeFixed()
+        {
+            return FixReferencesFlag;
         }
     }
 
@@ -69,7 +78,7 @@ namespace ripple.Commands
               .Step<DownloadMissingNugets>()
               .Step<ExplodeDownloadedNugets>()
               .Step<ProcessDirectives>()
-              //.Step<FixReferences>()
+              .Step<FixReferences>()
               .Execute();
         }
     }

--- a/src/ripple/Commands/RestoreCommand.cs
+++ b/src/ripple/Commands/RestoreCommand.cs
@@ -69,7 +69,7 @@ namespace ripple.Commands
               .Step<DownloadMissingNugets>()
               .Step<ExplodeDownloadedNugets>()
               .Step<ProcessDirectives>()
-              .Step<FixReferences>()
+              //.Step<FixReferences>()
               .Execute();
         }
     }

--- a/src/ripple/Steps/FixReferences.cs
+++ b/src/ripple/Steps/FixReferences.cs
@@ -5,13 +5,22 @@ using ripple.Model;
 
 namespace ripple.Steps
 {
+    public interface IManageReferenceFixing
+    {
+        bool ShouldReferencesBeFixed();
+    }
+
 	public class FixReferences : IRippleStep, DescribesItself
 	{
 		public Solution Solution { get; set; }
 
         public void Execute(RippleInput input, IRippleStepRunner runner)
-		{
-			var attacher = new ReferenceAttacher(Solution);
+        {
+            var manageFixing = input as IManageReferenceFixing;
+            if (manageFixing != null && manageFixing.ShouldReferencesBeFixed() == false)
+                return;
+
+            var attacher = new ReferenceAttacher(Solution);
 			attacher.Attach();
 		}
 


### PR DESCRIPTION
The ripple restore works pretty fast. What takes a lot of time is FixReferences step, which as far as I see it fixes projects. IMHO fixing projects for restore, especially one without --force flag, seems unnecessary.
The proposition is to provide a patch, where FixReferences step is removed from steps of restore. Waiting for your opinion.
