### PR TITLE
Support custom feeds when in classic mode

### DIFF
--- a/src/ripple.Testing/Classic/NuGetSolutionLoaderTester.cs
+++ b/src/ripple.Testing/Classic/NuGetSolutionLoaderTester.cs
@@ -1,5 +1,7 @@
+using FubuCore;
 using FubuTestingSupport;
 using NUnit.Framework;
+using Rhino.Mocks;
 using ripple.Classic;
 using ripple.Model;
 
@@ -104,4 +106,37 @@ namespace ripple.Testing.Classic
 			p2.Dependencies.Find("StructureMap").IsFloat().ShouldBeTrue();
 		}
 	}
+
+    [TestFixture]
+    public class load_adds_feeds
+    {
+        private SolutionConfig theConfig;
+        private Solution theSolution;
+        private Feed theFeed;
+
+        private NuGetSolutionLoader theLoader;
+
+        [SetUp]
+        public void SetUp()
+        {
+            theFeed = new Feed();
+            theConfig = new SolutionConfig
+                {
+                    Feeds = new[] {theFeed}
+                };
+
+            const string rippleConfig = "ripple.config";
+            var fileSystem = MockRepository.GenerateStub<IFileSystem>();
+            fileSystem.Stub(x => x.LoadFromFile<SolutionConfig>(rippleConfig)).Return(theConfig);
+            
+            theLoader = new NuGetSolutionLoader();
+            theSolution = theLoader.LoadFrom(fileSystem, rippleConfig);
+        }
+
+        [Test]
+        public void adds_the_feed_to_solution()
+        {
+            theSolution.Feeds.ShouldContain(theFeed);
+        }
+    }
 }

--- a/src/ripple/Classic/NuGetSolutionLoader.cs
+++ b/src/ripple/Classic/NuGetSolutionLoader.cs
@@ -20,6 +20,7 @@ namespace ripple.Classic
 			solution.FastBuildCommand = Config.FastBuildCommand;
 			solution.BuildCommand = Config.BuildCommand;
 			solution.NugetSpecFolder = Config.NugetSpecFolder;
+            solution.AddFeeds(Config.Feeds);
 
 			return solution;
 		}

--- a/src/ripple/Model/SolutionConfig.cs
+++ b/src/ripple/Model/SolutionConfig.cs
@@ -28,6 +28,7 @@ namespace ripple.Model
         public string FastBuildCommand { get; set; }
 
         private readonly IList<string> _floats = new List<string>();
+        private readonly IList<Feed> _feeds = new List<Feed>();
 
         public void FloatNuget(string nugetName)
         {
@@ -49,6 +50,16 @@ namespace ripple.Model
             {
                 _floats.Clear();
                 _floats.AddRange(value);
+            }
+        }
+
+        public Feed[] Feeds
+        {
+            get { return _feeds.ToArray(); }
+            set
+            {
+                _feeds.Clear();
+                _feeds.AddRange(value);
             }
         }
 


### PR DESCRIPTION
When in classic mode (ie. havent added any ripples.dependencies.config), i cannot add package from a custom feed. Dunno if i'm doing "ripple" totally wrong. but my flow was like so:
1. New solution
2. ripple init
3. Add custom feed to ripple.config
4. ripple install {some internal package} <-- didn't read the feeds from ripple.config

quite new to ripple so dunno if its a feature or a bug
