### PR TITLE
Convert <file src="" to native path for PublishedAssembly

### DIFF
--- a/src/ripple/Local/NuspecDocument.cs
+++ b/src/ripple/Local/NuspecDocument.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using FubuCore;
+using System.IO;
 
 namespace ripple.Local
 {
@@ -98,6 +99,7 @@ namespace ripple.Local
                 {
                     var path = target.Replace('\\', '/');
                     var assemblyReference = element.Attribute("src").Value;
+                    assemblyReference = assemblyReference.Replace('\\', Path.DirectorySeparatorChar);
 
                     yield return new PublishedAssembly(nuspecDirectory, assemblyReference, path);
                 }


### PR DESCRIPTION
Currently NugetSpecTester.should_read_the_name and NugetSpecTester.should_read_all_the_dependencies both fail due to incorrectly parsing of the path "....\src\FubuMVC.Core\bin\release\FubuMVC.Core.*", located in FubuMVCNuspecTemplate.txt, on 'unix'.

Following patch just ensure we convert the nuget spec file into 'native' file paths.

 As you can see the line a couple above my change 

var path = target.Replace('\', '/');

is still hardcoding the slash.   I have left this as is because that would break tests and im not entirely sure I understand its "use case" yet and therefore would probably break it even more.
