### PR TITLE
Fix rake create_gem which fails by copying files to file not a directory

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,3 +1,4 @@
+# vim: tabstop=4:softtabstop=4:shiftwidth=4:noexpandtab
 require 'fuburake'
 
 @solution = FubuRake::Solution.new do |sln|
@@ -33,9 +34,12 @@ end
 
 desc "Creates the gem for fubu.exe"
 task :create_gem => [:compile] do
-    require "rubygems/package"
+	require "rubygems/package"
+	include FileUtils
 	cleanDirectory 'bin';	
 	cleanDirectory 'pkg'
+	mkdir 'bin'
+	mkdir 'pkg'
 	
 	copyOutputFiles "src/ripple/bin/#{@solution.compilemode}", '*.dll', 'bin'
 	copyOutputFiles "src/ripple/bin/#{@solution.compilemode}", 'ripple.exe', 'bin'
@@ -71,5 +75,4 @@ task :create_gem => [:compile] do
 	FileUtils.mv "ripple-cli-#{@solution.options[:build_number]}.gem", "pkg/ripple-cli-#{@solution.options[:build_number]}.gem"
 	
 end
-
 


### PR DESCRIPTION
rake create_gem is currently broken as the copyOutputFiles treats 'bin' as a file name instead of a directory.  Therefore multiple files are copied and override a file bin.

By creating the directories first the behavour is as expected.

Error message on windows is

```  ripple.Testing -> C:\Projects\ripple\src\ripple.Testing\bin\Debug\ripple.Testing.dll
Cleaning directory bin
cp src/ripple/bin/Debug/FubuCore.dll bin
cp src/ripple/bin/Debug/NuGet.Core.dll bin
cp src/ripple/bin/Debug/ripple.exe bin
ON THE FLY SPEC FILES
# bin/ripple

rake aborted!
undefined method `build' for Gem::Package:Module
C:/Projects/ripple/rakefile.rb:69:in`block in <top (required)>'
Tasks: TOP => create_gem
(See full trace by running task with --trace)

```
```
