### PR TITLE
Branch detetion no longer relies on git.exe beeing on the path

### DIFF
--- a/src/ripple.Testing/Model/BranchDetectorTester.cs
+++ b/src/ripple.Testing/Model/BranchDetectorTester.cs
@@ -1,0 +1,36 @@
+﻿namespace ripple.Testing.Model
+{
+    using System;
+    using System.IO;
+    using NUnit.Framework;
+    using ripple.Model;
+
+    [TestFixture]
+    public class BranchDetectorTester
+    {
+        [Test]
+        public void Should_use_solution_dir_as_base_dir()
+        {
+            Assert.True(BranchDetector.CanDetectBranch());
+            Assert.IsNotEmpty(BranchDetector.Current());
+
+
+            BranchDetector.Live();
+
+            //simulate a no git dir
+            RippleFileSystem.StubCurrentDirectory(Path.GetTempPath());
+
+            Assert.False(BranchDetector.CanDetectBranch());
+
+            Assert.Throws<RippleFatalError>(() => BranchDetector.Current());
+
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            RippleFileSystem.Live();
+        }
+         
+    }
+}

--- a/src/ripple.Testing/ripple.Testing.csproj
+++ b/src/ripple.Testing/ripple.Testing.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Integration\updating_a_float_dependency_when_a_cached_version_exists.cs" />
     <Compile Include="Integration\valid_solution.cs" />
     <Compile Include="Model\BatchOperationTester.cs" />
+    <Compile Include="Model\BranchDetectorTester.cs" />
     <Compile Include="Model\FeedConnectivityTester.cs" />
     <Compile Include="Model\finding_project_nugets_to_restore.cs" />
     <Compile Include="Model\IgnoreAssemblyReferenceTester.cs" />

--- a/src/ripple/Model/BranchDetector.cs
+++ b/src/ripple/Model/BranchDetector.cs
@@ -1,33 +1,33 @@
 using System;
-using ripple.Local;
-using ripple.Runners;
 
 namespace ripple.Model
 {
+    using System.IO;
+
     public static class BranchDetector
     {
         private static Lazy<string> _current;
         private static Func<string> _detectCurrent;
-        private static Func<bool> _canDetect; 
- 
+        private static Func<bool> _canDetect;
+
         static BranchDetector()
         {
             Live();
         }
-        
+
         public static void Live()
         {
-            _canDetect = () => detectBranch().ExitCode == 0;
+            _canDetect = () => Directory.Exists(".git");
             _detectCurrent = () =>
             {
-                var returnValue = detectBranch();
-                if (returnValue.ExitCode != 0)
+                if (!_canDetect())
                 {
                     RippleAssert.Fail("Cannot use branch detection when not in a git repository");
                 }
 
-                var output = returnValue.OutputText;
-                return output.Substring(output.LastIndexOf('/') + 1).Replace("\n", string.Empty).Replace("\r", string.Empty).Trim();
+                var head = File.ReadAllText(".git\\HEAD");
+
+                return head.Substring(head.LastIndexOf("/") + 1).Trim();
             };
 
             reset();
@@ -36,12 +36,6 @@ namespace ripple.Model
         private static void reset()
         {
             _current = new Lazy<string>(_detectCurrent);
-        }
-
-        private static ProcessReturn detectBranch()
-        {
-            var startInfo = Runner.Git.Info("symbolic-ref HEAD");
-            return new ProcessRunner().Run(startInfo, x => { });
         }
 
         public static void Stub(Func<string> current)
@@ -57,14 +51,7 @@ namespace ripple.Model
 
         public static bool CanDetectBranch()
         {
-            try
-            {
-                return _canDetect();
-            }
-            catch (Exception)
-            {
-                return false;
-            }
+            return _canDetect();
         }
 
         public static string Current()

--- a/src/ripple/Model/BranchDetector.cs
+++ b/src/ripple/Model/BranchDetector.cs
@@ -17,7 +17,7 @@ namespace ripple.Model
 
         public static void Live()
         {
-            _canDetect = () => Directory.Exists(".git");
+            _canDetect = () => Directory.Exists(GitDirectory);
             _detectCurrent = () =>
             {
                 if (!_canDetect())
@@ -25,7 +25,7 @@ namespace ripple.Model
                     RippleAssert.Fail("Cannot use branch detection when not in a git repository");
                 }
 
-                var head = File.ReadAllText(".git\\HEAD");
+                var head = File.ReadAllText(Path.Combine(GitDirectory,"HEAD"));
 
                 return head.Substring(head.LastIndexOf("/") + 1).Trim();
             };
@@ -57,6 +57,14 @@ namespace ripple.Model
         public static string Current()
         {
             return _current.Value;
+        }
+
+        private static string GitDirectory
+        {
+            get
+            {
+                return Path.Combine(RippleFileSystem.FindSolutionDirectory(false) ?? "", ".git");
+            }
         }
     }
 }

--- a/src/ripple/RippleOperation.cs
+++ b/src/ripple/RippleOperation.cs
@@ -70,12 +70,6 @@ namespace ripple
 
         public bool Execute(bool throwOnFailure = false)
         {
-            // TODO -- This needs to be done as part of the new "activator" model
-            if (BranchDetector.CanDetectBranch())
-            {
-                BranchDetector.Current();
-            }
-
             foreach (var step in _steps)
             {
                 try
@@ -88,8 +82,7 @@ namespace ripple
                     _solution.Reset();
 
                     RippleLog.Error("Error executing {0}".ToFormat(step.GetType().Name), ex);
-                    //RippleLog.DebugMessage(_solution);
-
+                
                     // Mostly for testing
                     if (_forceThrow || throwOnFailure)
                     {


### PR DESCRIPTION
I've simplified the branch detector to not rely on git.exe to make it work more seamlessly on buildservers like TeamCity
