### PR TITLE
Adding support for CurrentMajor as a version constraint

### DIFF
--- a/src/ripple.Testing/Model/VersionTokenTester.cs
+++ b/src/ripple.Testing/Model/VersionTokenTester.cs
@@ -33,6 +33,15 @@ namespace ripple.Testing.Model
         }
 
         [Test]
+        public void current_major()
+        {
+            VersionToken
+                .CurrentMajor
+                .Value(new SemanticVersion("1.1.1.3467"))
+                .ShouldEqual(new SemanticVersion("1.0.0.0"));
+        }
+
+        [Test]
         public void next_min()
         {
             VersionToken

--- a/src/ripple/Model/VersionToken.cs
+++ b/src/ripple/Model/VersionToken.cs
@@ -10,9 +10,10 @@ namespace ripple.Model
     public class VersionToken
     {
         public static readonly VersionToken Current = new VersionToken("Current", x => x);
+        public static readonly VersionToken CurrentMajor = new VersionToken("CurrentMajor", x=>new SemanticVersion(x.Version.Major,0,0,0));
         public static readonly VersionToken NextMajor = new VersionToken("NextMajor", findNextMajor);
         public static readonly VersionToken NextMinor = new VersionToken("NextMinor", findNextMin);
-
+        
         private static readonly FieldInfo[] Fields;
         private static readonly Cache<string, VersionToken> Tokens;
  


### PR DESCRIPTION
Since we follow SemVer we can have our default Float constraint set to CurrentMajor 

eg: [4.0.0.0, 5.0.0.0)
