### PR TITLE
Add Basic authentication for remote feeds.

### DIFF
--- a/src/ripple/Model/Feed.cs
+++ b/src/ripple/Model/Feed.cs
@@ -41,6 +41,10 @@ namespace ripple.Model
 		public UpdateMode Mode { get; set; }
         [XmlAttribute]
         public NugetStability Stability { get; set; }
+        [XmlAttribute]
+        public string Password { get; set; }
+        [XmlAttribute]
+        public string Username { get; set; }
 
 		public INugetFeed GetNugetFeed()
 		{

--- a/src/ripple/Model/FeedRegistry.cs
+++ b/src/ripple/Model/FeedRegistry.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using FubuCore;
 using FubuCore.Util;
+using NuGet;
 using ripple.Nuget;
 
 namespace ripple.Model
@@ -44,6 +46,15 @@ namespace ripple.Model
             if (feed.Url.StartsWith("file://"))
             {
                 return buildFileSystemFeed(feed);
+            }
+
+            if (!String.IsNullOrEmpty(feed.Username) && !String.IsNullOrEmpty(feed.Password))
+            {
+                if (HttpClient.DefaultCredentialProvider.GetType() != NugetCredentialsProvider.Instance.GetType())
+                {
+                    HttpClient.DefaultCredentialProvider = NugetCredentialsProvider.Instance;
+                }
+                NugetCredentialsProvider.Instance.AddCredentials(feed.Url, new NetworkCredential(feed.Username, feed.Password));
             }
 
             if (feed.Mode == UpdateMode.Fixed)

--- a/src/ripple/Nuget/NugetCredentialsProvider.cs
+++ b/src/ripple/Nuget/NugetCredentialsProvider.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Linq;
+using NuGet;
+
+namespace ripple.Nuget
+{
+    public class NugetCredentialsProvider : ICredentialProvider
+    {
+        private readonly Dictionary<string, ICredentials> _credentials = new Dictionary<string, ICredentials>();
+        private static readonly Lazy<NugetCredentialsProvider> lazy = new Lazy<NugetCredentialsProvider>(() => new NugetCredentialsProvider()); 
+
+        private NugetCredentialsProvider() {}
+
+        public static NugetCredentialsProvider Instance { get { return lazy.Value; } }
+
+        public void AddCredentials(string key, ICredentials credentials)
+        {
+            _credentials.Add(key, credentials);
+        }
+
+        public ICredentials GetCredentials(Uri uri, IWebProxy proxy, CredentialType credentialType, bool retrying)
+        {
+            return _credentials[uri.OriginalString];
+        }
+
+        public bool TryGetCredentials(string uri, out ICredentials credentials)
+        {
+            if (_credentials.ContainsKey(uri))
+            {
+                credentials = _credentials[uri];
+                return true;
+            }
+            credentials = null;
+            return false;
+        }
+        
+        public bool TryGetRootCredentials(string uri, out ICredentials credentials)
+        {
+            var matchingRoot =
+                    _credentials.Keys
+                        .SingleOrDefault(credUrl => uri.StartsWith(credUrl, StringComparison.InvariantCultureIgnoreCase));
+            if (!String.IsNullOrEmpty(matchingRoot))
+            {
+                credentials = _credentials[matchingRoot];
+                return true;
+            }
+            credentials = null;
+            return false;
+        }
+    }
+}

--- a/src/ripple/Nuget/NugetFeed.cs
+++ b/src/ripple/Nuget/NugetFeed.cs
@@ -48,6 +48,11 @@ namespace ripple.Nuget
             {
                 using (var client = new WebClient())
                 {
+                    ICredentials credentials;
+                    if (NugetCredentialsProvider.Instance.TryGetCredentials(_url, out credentials))
+                    {
+                        client.Credentials = credentials;
+                    }
                     using (var stream = client.OpenRead(_url))
                     {
                         return true;

--- a/src/ripple/Nuget/UrlNugetDownloader.cs
+++ b/src/ripple/Nuget/UrlNugetDownloader.cs
@@ -25,6 +25,12 @@ namespace ripple.Nuget
             var client = new WebClient();
 
             Console.WriteLine("Downloading {0} to {1}", Url, filename);
+		    ICredentials creds;
+            if (NugetCredentialsProvider.Instance.TryGetRootCredentials(Url, out creds))
+            {
+                client.Credentials = creds;
+            }
+            
             client.DownloadFile(Url, filename);
 
             return new NugetFile(filename, mode);

--- a/src/ripple/ripple.csproj
+++ b/src/ripple/ripple.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Nuget\INugetFilter.cs" />
     <Compile Include="Nuget\INugetFinder.cs" />
     <Compile Include="Nuget\NoMaxVersionSpecFinder.cs" />
+    <Compile Include="Nuget\NugetCredentialsProvider.cs" />
     <Compile Include="Nuget\NugetProblem.cs" />
     <Compile Include="Nuget\NugetResult.cs" />
     <Compile Include="Model\NulloDependencyStrategy.cs" />


### PR DESCRIPTION
A fix for issue #156

Apologies for the global singleton class for managing the authentications; as this is basically Nuget's strategy for handling the problem I've not thought of a better work around.

This code has been tested manually and worked correctly against a private MyGet feed. Usage involves adding a Username and Password attribute to the feed that needs authentication.
