### PR TITLE
Fixing problems with online feeds with 100+ packages + tests

### DIFF
--- a/src/ripple.Testing/App.config
+++ b/src/ripple.Testing/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.net>
+    <defaultProxy enabled="true" useDefaultCredentials="true">
+    </defaultProxy>
+  </system.net>
+</configuration>

--- a/src/ripple.Testing/Nuget/FloatingFinderTester.cs
+++ b/src/ripple.Testing/Nuget/FloatingFinderTester.cs
@@ -1,4 +1,5 @@
-﻿using FubuTestingSupport;
+﻿using System.Linq;
+using FubuTestingSupport;
 using NUnit.Framework;
 using NuGet;
 using ripple.Model;
@@ -56,6 +57,29 @@ namespace ripple.Testing.Nuget
             var result = theFinder.Find(theSolution, new Dependency("Test", "1.0.0.0", UpdateMode.Fixed));;
 
             result.Found.ShouldBeFalse();
+        }
+
+        [Test]
+        [Explicit]
+        public void load_all_packages_from_feed_with_100plus_packages()
+        {
+            var feedUrl = Feed.NuGetV2.Url;
+
+            var feed = new FloatingFeed(feedUrl, NugetStability.Anything);
+
+            Assert.IsTrue(feed.GetLatest().Count() > 100, feedUrl + " has more than 100 packages");
+        }
+
+
+        [Test]
+        [Explicit]
+        public void find_packages_by_name_from_feed_with_100plus_packages()
+        {
+            var feedUrl = Feed.NuGetV2.Url;
+
+            var feed = new FloatingFeed(feedUrl, NugetStability.Anything);
+
+            Assert.NotNull(feed.FindLatestByName("MiniProfiler"), "Package should be on nuget feed " + feedUrl);
         }
     }
 }

--- a/src/ripple.Testing/ripple.Testing.csproj
+++ b/src/ripple.Testing/ripple.Testing.csproj
@@ -246,6 +246,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="Bottles.1.0.0.441.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
The problem which I had was with nuget.org on which FloatingFeed.cs cannot find package by name.
It was caused by wrongly method with downloading all packages from feed. The previous way was trying to use following query: /Packages()?$filter=IsLatestVersion&$orderby=DownloadCount%20desc,Id&$skip={0}&$top=100. 
But nuget.org returns only 40 packages even if top=100 is specified.
I added test (named load_all_packages_from_feed_with_100plus_packages) which shows this problem.

Moreover I decided to optimize way of getting latest in findLatest method. Previously it was done by downloading all packages from feed and then query it for selected packages. Instead I deiced to query for specified packages, which doesn't need to download full feed.
