### PR TITLE
Ripple on internet access env

### DIFF
--- a/src/ripple/Model/IFeedConnectivity.cs
+++ b/src/ripple/Model/IFeedConnectivity.cs
@@ -52,7 +52,6 @@ namespace ripple.Model
 
             var solutionFeeds = solution.Feeds.Select(x => x.GetNugetFeed()).ToArray();
 
-            //TODO: check if following if is enought
             if (!AllOffline(solutionFeeds))
             {
                 foreach (var feed in solutionFeeds)

--- a/src/ripple/Model/IFeedConnectivity.cs
+++ b/src/ripple/Model/IFeedConnectivity.cs
@@ -52,7 +52,8 @@ namespace ripple.Model
 
             var solutionFeeds = solution.Feeds.Select(x => x.GetNugetFeed()).ToArray();
 
-            if (RippleEnvironment.Connected() && !AllOffline(solutionFeeds))
+            //TODO: check if following if is enought
+            if (!AllOffline(solutionFeeds))
             {
                 foreach (var feed in solutionFeeds)
                 {


### PR DESCRIPTION
During checking if all feed are online, where is a call `RippleEnvironment.Connected()`. It checks if nuget.org is online/accessible. In my opinion it is completely wrong especially when working with own nuget gallery and official nuget.org is not even in ripple.config.
