### PR TITLE
Floating dependency should skip version check

### DIFF
--- a/src/ripple.Testing/App.config
+++ b/src/ripple.Testing/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.net>
+    <defaultProxy enabled="true" useDefaultCredentials="true">
+    </defaultProxy>
+  </system.net>
+</configuration>

--- a/src/ripple.Testing/Nuget/FloatingFinderTester.cs
+++ b/src/ripple.Testing/Nuget/FloatingFinderTester.cs
@@ -1,4 +1,5 @@
-﻿using FubuTestingSupport;
+﻿using System.Linq;
+using FubuTestingSupport;
 using NUnit.Framework;
 using NuGet;
 using ripple.Model;
@@ -56,6 +57,29 @@ namespace ripple.Testing.Nuget
             var result = theFinder.Find(theSolution, new Dependency("Test", "1.0.0.0", UpdateMode.Fixed));;
 
             result.Found.ShouldBeFalse();
+        }
+
+        [Test]
+        [Explicit]
+        public void load_all_packages_from_feed_with_100plus_packages()
+        {
+            var feedUrl = Feed.NuGetV2.Url;
+
+            var feed = new FloatingFeed(feedUrl, NugetStability.Anything);
+
+            Assert.IsTrue(feed.GetLatest().Count() > 100, feedUrl + " has more than 100 packages");
+        }
+
+
+        [Test]
+        [Explicit]
+        public void find_packages_by_name_from_feed_with_100plus_packages()
+        {
+            var feedUrl = Feed.NuGetV2.Url;
+
+            var feed = new FloatingFeed(feedUrl, NugetStability.Anything);
+
+            Assert.NotNull(feed.FindLatestByName("MiniProfiler"), "Package should be on nuget feed " + feedUrl);
         }
     }
 }

--- a/src/ripple.Testing/Nuget/NugetFeedTester.cs
+++ b/src/ripple.Testing/Nuget/NugetFeedTester.cs
@@ -36,5 +36,17 @@ namespace ripple.Testing.Nuget
 
             task.Result.Nuget.Version.ShouldEqual(new SemanticVersion("1.0.1"));
         }
+
+        [Test]
+        public void restore_solution_dependencies()
+        {
+            var notExistingVersion = new SemanticVersion("1.0.0");
+            var fixedFeed = new NugetFeed(Feed.NuGetV2.Url, NugetStability.ReleasedOnly);
+            fixedFeed.Find(new Dependency("Newtonsoft.Json", notExistingVersion, UpdateMode.Float)
+            {
+                NugetStability = NugetStability.ReleasedOnly,
+                Mode = UpdateMode.Float
+            }).ShouldNotBeNull();
+        }
     }
 }

--- a/src/ripple.Testing/ripple.Testing.csproj
+++ b/src/ripple.Testing/ripple.Testing.csproj
@@ -246,6 +246,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="Bottles.1.0.0.441.nupkg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/ripple/Nuget/NugetFeed.cs
+++ b/src/ripple/Nuget/NugetFeed.cs
@@ -77,8 +77,9 @@ namespace ripple.Nuget
             }
 
             var versionSpec = new VersionSpec(version);
+            
             var package = repository
-                .FindPackages(query.Name, versionSpec, query.DetermineStability(Stability) == NugetStability.Anything, true)
+                .FindPackages(query.Name, query.IsFloat()? null: versionSpec, query.DetermineStability(Stability) == NugetStability.Anything, true)
                 .OrderByDescending(x => x.Version)
                 .FirstOrDefault();
 


### PR DESCRIPTION
There is a problem with following configuration:
1) Nuget feed is marked as fixed
2) Dependency is marked as float but has specified version in file (e.g.: nuget 'Microsoft.Net.Http', version: '2.0.20710.0', mode: 'Float' in ripple file)

The above configuration works differently comparing to: nuget 'Microsoft.Net.Http',  mode: 'Float'

In my opinion these two are exactly, because in Float mode version doesn't change anything.
