### PR TITLE
dependencies node is not mandatory

### DIFF
--- a/src/ripple.Testing/Nuget/NuspecDocumentTester.cs
+++ b/src/ripple.Testing/Nuget/NuspecDocumentTester.cs
@@ -1,0 +1,48 @@
+﻿using NuGet;
+using NUnit.Framework;
+using ripple.Nuget;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FubuTestingSupport;
+using System.Xml.Linq;
+
+namespace ripple.Testing.Nuget
+{
+    public class NuspecDocumentTester
+    {
+        public NuspecDocument createDocument(string fileName, string id, string version)
+        {
+            XNamespace  ns = NuspecDocument.Schema;
+            var xdoc = (new XDocument(new XElement(ns + "package", 
+                new XElement(ns + "metadata",
+                    new XElement(ns + "id",
+                        new XText(id)
+                     ),
+                     new XElement(ns + "version",
+                        new XText(version)
+                     )
+             ))));
+            xdoc.Save(fileName);
+            var doc = new NuspecDocument(fileName);
+            return doc;
+        }
+
+        [Test]
+        public void when_no_depency_add_depency_works()
+        {
+            var fileName = Path.GetTempFileName();
+            var doc = createDocument(fileName, "Test", "1.2.1");
+            doc.AddDependency(new NuspecDependency()
+            {
+                Name = "Test2",
+                VersionSpec = new VersionSpec(SemanticVersion.Parse("1.0.0"))
+            });
+            doc.FindDependencies().ShouldContain(c => c.Name == "Test2");
+
+            File.Delete(fileName);
+        }
+    }
+}

--- a/src/ripple.Testing/ripple.Testing.csproj
+++ b/src/ripple.Testing/ripple.Testing.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Nuget\NugetSearchTester.cs" />
     <Compile Include="Nuget\NugetStepRunnerTester.cs" />
     <Compile Include="Nuget\NugetXmlFeedTester.cs" />
+    <Compile Include="Nuget\NuspecDocumentTester.cs" />
     <Compile Include="Nuget\Operations\installing_a_fixed_project_dependency_any_stability.cs" />
     <Compile Include="Nuget\Operations\installing_a_fixed_project_dependency_released_only.cs" />
     <Compile Include="Nuget\Operations\installing_a_fixed_project_dependency_with_existing_transitive_dependencies.cs" />

--- a/src/ripple/Nuget/NuspecDocument.cs
+++ b/src/ripple/Nuget/NuspecDocument.cs
@@ -63,12 +63,15 @@ namespace ripple.Nuget
         {
             var dependencies = _document.XPathSelectElement("//nuspec:dependencies", _xmlNamespaceManager);
 
-            foreach (XElement dependencyElement in dependencies.Nodes())
+            if (dependencies != null)
             {
-                if (dependencyElement.Attribute("id").Value == dependency.Name)
+                foreach (XElement dependencyElement in dependencies.Nodes())
                 {
-                    dependencyElement.SetAttributeValue("version", dependency.VersionSpec.ToString());
-                    return;
+                    if (dependencyElement.Attribute("id").Value == dependency.Name)
+                    {
+                        dependencyElement.SetAttributeValue("version", dependency.VersionSpec.ToString());
+                        return;
+                    }
                 }
             }
 

--- a/src/ripple/Nuget/NuspecDocument.cs
+++ b/src/ripple/Nuget/NuspecDocument.cs
@@ -63,15 +63,19 @@ namespace ripple.Nuget
         {
             var dependencies = _document.XPathSelectElement("//nuspec:dependencies", _xmlNamespaceManager);
 
-            if (dependencies != null)
+            if (dependencies == null)
             {
-                foreach (XElement dependencyElement in dependencies.Nodes())
+                var metadata = _document.XPathSelectElement("//nuspec:metadata", _xmlNamespaceManager);
+                dependencies = new XElement(XName.Get("dependencies", Schema));
+                metadata.Add(dependencies);
+            }
+
+            foreach (XElement dependencyElement in dependencies.Nodes())
+            {
+                if (dependencyElement.Attribute("id").Value == dependency.Name)
                 {
-                    if (dependencyElement.Attribute("id").Value == dependency.Name)
-                    {
-                        dependencyElement.SetAttributeValue("version", dependency.VersionSpec.ToString());
-                        return;
-                    }
+                    dependencyElement.SetAttributeValue("version", dependency.VersionSpec.ToString());
+                    return;
                 }
             }
 


### PR DESCRIPTION
If there is no dependency node in nuspec, XPathSelectElement return null
