### PR TITLE
fix multiple change to csprojfile with some pkg

### DIFF
--- a/src/ripple/MSBuild/ReferenceAttacher.cs
+++ b/src/ripple/MSBuild/ReferenceAttacher.cs
@@ -41,6 +41,7 @@ namespace ripple.MSBuild
 
         private void fixProject(Project project)
         {
+            var assembliesDico = new Dictionary<string, IPackageAssemblyReference>();
             project.Dependencies.Each(dep =>
             {
                 var package = _packages[dep.Name];
@@ -59,8 +60,12 @@ namespace ripple.MSBuild
                     project.Proj.AddAssemblies(dep, explicitRefs, assemblies);
                     return;
                 }
-
-                project.Proj.AddAssemblies(dep, assemblies);
+                project.Proj.AddAssemblies(dep, assemblies.Where(c => !assembliesDico.ContainsKey(c.Name)));
+                assemblies.Each(a =>
+                    {
+                        if (!assembliesDico.ContainsKey(a.Name))
+                            assembliesDico.Add(a.Name, a);
+                    });
             });
         }
     }


### PR DESCRIPTION
When using a package that include another dll in his lib folder. And the
other dll exists as a package, then csprojfile are changed multiple
times du to addassemblies save. In that case we have a reload all window
on vs.

Package creating conflicts :
- TweetSharp-Unofficial (embed hammock and newtonsoftjson)

To reproduce the issue, install TweetSharp-Unofficial then newtonsoftjson (or hammock) in project.
You'll see the csproj file wirte change every time the task FixReferences is runned.
