### PR TITLE
Update to new cs proj file and minimize changes

### DIFF
--- a/ripple.config
+++ b/ripple.config
@@ -14,8 +14,8 @@
   </Feeds>
   <Nugets>
     <Dependency Name="Bottles" Version="2.0.0.550" Mode="Float" />
-    <Dependency Name="FubuCore" Version="1.1.0.242" Mode="Float" />
-    <Dependency Name="FubuCsProjFile" Version="1.2.0.88" Mode="Float" />
+    <Dependency Name="FubuCore" Version="1.3.0.278" Mode="Float" />
+    <Dependency Name="FubuCsProjFile" Version="1.5.0.130" Mode="Float" />
     <Dependency Name="FubuObjectBlocks" Version="0.1.0.7" Mode="Float" />
     <Dependency Name="Nuget.Core" Version="2.8.0" Mode="Fixed" />
     <Dependency Name="NUnit" Version="2.5.10.11092" Mode="Fixed" />

--- a/src/ripple/MSBuild/ProjFile.cs
+++ b/src/ripple/MSBuild/ProjFile.cs
@@ -8,6 +8,7 @@ using FubuCsProjFile;
 using NuGet;
 using ripple.Model;
 using Solution = ripple.Model.Solution;
+using FubuCsProjFile.MSBuild;
 
 namespace ripple.MSBuild
 {
@@ -30,6 +31,7 @@ namespace ripple.MSBuild
             {
                 _project = CsProjFile.CreateAtLocation(_filename, solution.Name);
             }
+            _project.BuildProject.Settings = MSBuildProjectSettings.MinimizeChanges;
         }
 
         public CsProjFile Project { get { return _project; } }


### PR DESCRIPTION
So we don't have to reload all projects when updating or installing
packages
