### PR TITLE
Tell Nuget that we are a commandline application so it doesn't use Weak ...

### DIFF
--- a/src/ripple/Nuget/NugetFeed.cs
+++ b/src/ripple/Nuget/NugetFeed.cs
@@ -20,6 +20,11 @@ namespace ripple.Nuget
             Stability = stability;
 
             _online = new Lazy<bool>(isOnline);
+
+            // Tell Nuget that we are a commandline application so it doesn't use Weak Event Handling
+            // http://msdn.microsoft.com/en-us/library/aa970850(v=vs.100).aspx which is not
+            // currently implemented in mono.
+            EnvironmentUtility.SetRunningFromCommandLine ();
         }
 
         private IPackageRepository repository


### PR DESCRIPTION
...Event Handling

http://msdn.microsoft.com/en-us/library/aa970850(v=vs.100).aspx which is not
currently implemented in mono.

basically here are the lines of code im trying to work around.
https://github.com/Haacked/NuGet/blob/ffdbd1430b47e66ef7341b4ddd8e4c8543afcea1/src/Core/Repositories/DataServicePackageRepository.cs#L65-L73

the else statement blows up on mono with NotImplementedException.
